### PR TITLE
Temporary fix for 5.6 support

### DIFF
--- a/src/GaeaUnrealTools.uplugin
+++ b/src/GaeaUnrealTools.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "https://gaea.app/uedocs",
 	"MarketplaceURL": "",
 	"SupportURL": "",
-	"EngineVersion": "5.5.0",
+	"EngineVersion": "5.6.0",
 	"CanContainContent": true,
 	"IsBetaVersion": false,
 	"Installed": true,

--- a/src/Source/GaeaUEToolsEditor/Private/GaeaSubsystem.cpp
+++ b/src/Source/GaeaUEToolsEditor/Private/GaeaSubsystem.cpp
@@ -494,7 +494,7 @@ void UGaeaSubsystem::ReimportGaeaWPTerrain()
 										if (Landscape->bCanHaveLayersContent)
 										{
 											const FLandscapeLayer* BaseLayer = Landscape->GetLayerConst(0);
-											FGuid ID = BaseLayer->Guid;
+											FGuid ID = BaseLayer->Guid_DEPRECATED;
 											LandscapeEdit.SetEditLayer(ID);
 
 											LandscapeEdit.SetHeightData(

--- a/src/Source/GaeaUEToolsEditor/Public/GaeaCommands.h
+++ b/src/Source/GaeaUEToolsEditor/Public/GaeaCommands.h
@@ -12,7 +12,7 @@ class GAEAUETOOLSEDITOR_API FGaeaCommands : public TCommands<FGaeaCommands>
 {
 public:
 	
-	FGaeaCommands() : TCommands(TEXT("Gaea"), NSLOCTEXT("Contexts", "Gaea", "Gaea Commands"), NAME_None, FEditorStyle::GetStyleSetName())
+	FGaeaCommands() : TCommands(TEXT("Gaea"), NSLOCTEXT("Contexts", "Gaea", "Gaea Commands"), NAME_None, FEditorStyle::GetAppStyleSetName())
 	{
 	}
 


### PR DESCRIPTION
- BaseLayer->Guid to BaseLayer->Guid_DEPRECATED
- FEditorStyle::GetStyleSetName() to FEditorStyle::GetAppStyleSetName()

Project builds and everything works, however it uses deprecated Guid. Proper replacement still needs to be found.


Implemented change noted in #4